### PR TITLE
C test python

### DIFF
--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install gitpython
+        pip install pytest gitpython
 
     - name: Configure
       run: |

--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -28,4 +28,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install gitpython
+
+    - name: Configure
+      run: |
+           cmake -B build -S .
+
+    - name: Running python tests
+      run: |
+           cd build
+           ctest -C ${{ matrix.buildtype }} --output-on-failure
     

--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         os: [windows-latest]
         buildtype: [release]
-        python-version: [3.6]
+        # python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v2 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    # - name: Set up Python ${{ matrix.python-version }}
+    #   uses: actions/setup-python@v2
+    #   with:
+    #     python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -15,14 +15,17 @@ jobs:
       matrix:
         os: [windows-latest]
         buildtype: [release]
-        # python-version: [3.6]
+        python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v2 
-    # - name: Set up Python ${{ matrix.python-version }}
-    #   uses: actions/setup-python@v2
-    #   with:
-    #     python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [windows-latest]
         buildtype: [release]
-        python-version: [3.8]
+        python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v2 

--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+      run: python -c "import sys; print(sys.version)"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-tests-win.yml
+++ b/.github/workflows/python-tests-win.yml
@@ -1,0 +1,31 @@
+name: Windows CI for python tests
+
+on:
+  push:
+    branches:
+      - CTest-python
+
+jobs:
+
+  windows:
+  
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [windows-latest]
+        buildtype: [release]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2 
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install gitpython
+    

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest]
         buildtype: [release]
         python-version: [3.6]
 

--- a/.github/workflows/ubuntu--apt-get.yml
+++ b/.github/workflows/ubuntu--apt-get.yml
@@ -1,6 +1,9 @@
 name: ubuntu with apt-get
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
 
 jobs:
   ubuntu--apt-get:

--- a/.github/workflows/ubuntu--build-deps.yml
+++ b/.github/workflows/ubuntu--build-deps.yml
@@ -1,6 +1,9 @@
 name: ubuntu - deps downloaded
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
 
 jobs:
   ubuntu--build-deps:

--- a/.github/workflows/windows--build-deps.yml
+++ b/.github/workflows/windows--build-deps.yml
@@ -1,6 +1,9 @@
 name: windows - deps downloaded
 
-on: push
+on:
+  push:
+    branches:
+    - master
 
 jobs:
 

--- a/.github/workflows/windows--vcpkg.yml
+++ b/.github/workflows/windows--vcpkg.yml
@@ -1,6 +1,9 @@
 name: windows with vcpkg
 
-on: push
+on:
+  push:
+    branches:
+    - master
 
 jobs:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ message("*** python-tests : ${CMAKE_CURRENT_SOURCE_DIR}/ctest-python/python-test
 
 enable_testing()
 
-find_package(Python3 COMPONENTS Interpreter)
+find_package(Python3 3.6 COMPONENTS Interpreter)
 
 if(Python3_Interpreter_FOUND)
 	add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ message("*** python-tests : ${CMAKE_CURRENT_SOURCE_DIR}/ctest-python/python-test
 
 enable_testing()
 
-find_package(Python3 3.6 COMPONENTS Interpreter)
+find_package(Python3 EXACT 3.6 COMPONENTS Interpreter)
 
 if(Python3_Interpreter_FOUND)
 	add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ message("*** python-tests : ${CMAKE_CURRENT_SOURCE_DIR}/ctest-python/python-test
 
 enable_testing()
 
-find_package(python3 COMPONENTS Interpreter)
+find_package(Python3 COMPONENTS Interpreter)
 
 if(Python3_Interpreter_FOUND)
 	add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,3 +46,22 @@ if(BUILD_TESTING)
 	
 	add_subdirectory(tests)
 endif()
+
+# Only for running python tests (with pyTest) using CTest
+# add_subdirectory(ctest-python)
+
+
+message("*** CMAKE_CURRENT_SOURCE_DIR : ${CMAKE_CURRENT_SOURCE_DIR}")
+message("*** python-tests : ${CMAKE_CURRENT_SOURCE_DIR}/ctest-python/python-tests")
+
+enable_testing()
+
+find_package(python3 COMPONENTS Interpreter)
+
+if(Python3_Interpreter_FOUND)
+	add_test(
+			NAME small-python-tests
+			COMMAND Python3::Interpreter -m pytest -v -q test_small_python_tests.py
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ctest-python/python-tests"
+			)
+endif()

--- a/ctest-python/python-tests/test_small_python_tests.py
+++ b/ctest-python/python-tests/test_small_python_tests.py
@@ -1,0 +1,29 @@
+import pytest
+import time
+import git
+import os
+
+@pytest.fixture
+def get_repo(scope="session", autouse = True):
+	
+	return git.Repo.clone_from('https://gitlab.com/antares-rte/sandbox.git', os.getcwd() + os.sep + 'sandbox')
+
+
+# print("hello")
+
+def test_getRepo(get_repo):
+	# cloned_repo = get_repo
+	assert 0 == 0
+
+def test_one():
+	time.sleep(1)
+	assert 1 == 1
+	
+def test_two():
+	time.sleep(1)
+	
+	assert 2 == 2
+
+def test_three():
+	time.sleep(1)
+	assert 3 == 3

--- a/ctest-python/python-tests/test_small_python_tests.py
+++ b/ctest-python/python-tests/test_small_python_tests.py
@@ -6,7 +6,7 @@ import os
 @pytest.fixture
 def get_repo(scope="session", autouse = True):
 	
-	return git.Repo.clone_from('https://gitlab.com/antares-rte/sandbox.git', os.getcwd() + os.sep + 'sandbox')
+	return git.Repo.clone_from('https://github.com/AntaresSimulatorTeam/Antares_Simulator_Tests.git', os.getcwd() + os.sep + 'Antares_Simulator_Tests')
 
 
 # print("hello")

--- a/ctest-python/readme.txt
+++ b/ctest-python/readme.txt
@@ -9,8 +9,9 @@ Run tests :
 > cd build
 > ctest -C release --output-on-failure
 
-remove manually : FizzBuzz/python-tests/sandbox
+remove manually : FizzBuzz/ctest-python/python-tests/Antares_Simulator_Tests
 
 ------------
 For Ubuntu
 ------------
+Same as for Windows

--- a/ctest-python/readme.txt
+++ b/ctest-python/readme.txt
@@ -1,0 +1,16 @@
+-------------
+For Windows
+-------------
+Cmake configuration :
+> cd FizzBuzz
+> cmake -B build -S .
+
+Run tests :
+> cd build
+> ctest -C release --output-on-failure
+
+remove manually : FizzBuzz/python-tests/sandbox
+
+------------
+For Ubuntu
+------------


### PR DESCRIPTION
POC pour le lancement, via CTest, d'un script python comportant des tests courts, joués avec pytest.
La première action de ce script consiste à télécharger le contenu d'un dépôt distant contenant des études Antares.
Ces études ne sont pas utilisées dans le script python, le téléchargement n'étant présent que pour vérifier sa faisabilité.

Ce dépôt est originellement dédié à la mise en place de tests (via CTest) pour un petit programme fizzBuzz écrit en C++.
Déjà en place, il sert opportunément à ce nouveau POC, mais la CI du fizzBuzz à été désativée dans cette branche.

A noter : 
la version de l'interpréteur python demandé dans le CMake (mot clé EXACT) doit correspondre (pour l'instant) à celle demandée dans le yaml de la CI :  sinon, au moment de la CI, le CTest prend une version de python présente par défaut sur les runner github (3.9.0) et comme pytest n'est pas installé pour cette version, ça plante.